### PR TITLE
Add local image generation tools

### DIFF
--- a/dria-agent-deep-research.py
+++ b/dria-agent-deep-research.py
@@ -25,6 +25,7 @@ from livekit.agents.pipeline import AgentCallContext, VoicePipelineAgent
 from livekit.plugins import openai, silero, turn_detector
 from livekit.plugins.openai.tts import TTS
 from firecrawl import FirecrawlApp
+import image_tools
 load_dotenv(dotenv_path=".env.local")
 
 logger = logging.getLogger("voice-agent")
@@ -1089,6 +1090,72 @@ class AssistantFnc(llm.FunctionContext):
             "speech_results": "I couldn't find any details for this research. Would you like me to start a new research task?",
             "chat_results": "I couldn't find any details for this research. Would you like me to start a new research task?"
         }
+
+    @llm.ai_callable()
+    async def generate_image(
+        self,
+        prompt: Annotated[
+            str,
+            llm.TypeInfo(
+                description="The prompt describing the image to generate."
+            ),
+        ],
+        num_images: Annotated[
+            int,
+            llm.TypeInfo(
+                description="Number of images to generate (1-4, default: 1)",
+            ),
+        ] = 1,
+    ):
+        """Generate images from a text prompt using a local image model."""
+        agent = AgentCallContext.get_current().agent
+
+        num_images = min(max(1, num_images), 4)
+
+        try:
+            images = await image_tools.generate_image(prompt, num_images=num_images)
+            if images:
+                await agent.say("I've generated the image you requested.", add_to_chat_ctx=True)
+            else:
+                await agent.say("I wasn't able to generate an image.", add_to_chat_ctx=True)
+            return {"prompt": prompt, "images": images}
+        except Exception as e:
+            logger.error(f"Error generating image: {e}")
+            error_msg = "I ran into a problem while generating the image."
+            await agent.say(error_msg, add_to_chat_ctx=True)
+            return {"error": str(e)}
+
+    @llm.ai_callable()
+    async def edit_image(
+        self,
+        image_url: Annotated[
+            str,
+            llm.TypeInfo(
+                description="URL of the image to edit."
+            ),
+        ],
+        prompt: Annotated[
+            str,
+            llm.TypeInfo(
+                description="Description of the desired edits to the image."
+            ),
+        ],
+    ):
+        """Edit an existing image using a local image model."""
+        agent = AgentCallContext.get_current().agent
+
+        try:
+            edited = await image_tools.edit_image(image_url, prompt)
+            if edited:
+                await agent.say("Here's the edited image.", add_to_chat_ctx=True)
+            else:
+                await agent.say("I couldn't edit the image.", add_to_chat_ctx=True)
+            return {"edited_image": edited}
+        except Exception as e:
+            logger.error(f"Error editing image: {e}")
+            error_msg = "I encountered a problem while editing the image."
+            await agent.say(error_msg, add_to_chat_ctx=True)
+            return {"error": str(e)}
 
 
 

--- a/image_tools.py
+++ b/image_tools.py
@@ -1,0 +1,25 @@
+import os
+import aiohttp
+from typing import List
+
+IMAGE_API_URL = os.environ.get("IMAGE_API_URL", "http://localhost:8081")
+
+async def generate_image(prompt: str, num_images: int = 1) -> List[str]:
+    """Generate images from a text prompt via a local image generation API."""
+    url = f"{IMAGE_API_URL}/generate"
+    payload = {"prompt": prompt, "num_images": num_images}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=payload) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+            return data.get("images", [])
+
+async def edit_image(image_url: str, prompt: str) -> str:
+    """Edit an existing image based on the prompt via a local API."""
+    url = f"{IMAGE_API_URL}/edit"
+    payload = {"image_url": image_url, "prompt": prompt}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=payload) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+            return data.get("edited_image", "")

--- a/system_prompt.txt
+++ b/system_prompt.txt
@@ -19,7 +19,10 @@ Trigger this when you hear phrases like: "research deeply", "investigate thoroug
 This process takes a few minutes but provides more thorough results than a quick search.
 You can check the status of ongoing research with check_research_status when the user asks about progress.
 
+Image Capabilities:
 
+You can generate images or edit existing ones using the generate_image and edit_image functions.
+Trigger this when you hear phrases like: "create an image of", "draw", "edit this picture", or similar requests.
 
 Voice Output Guidelines:
 


### PR DESCRIPTION
## Summary
- add `image_tools.py` for basic image generation and editing via a local API
- expose `generate_image` and `edit_image` through `AssistantFnc`
- mention new image capabilities in `system_prompt.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a7ad95608330bab9cf70ed95df3c