### PR TITLE
Add photo tools and integrate with assistant

### DIFF
--- a/dria-agent-deep-research.py
+++ b/dria-agent-deep-research.py
@@ -11,6 +11,7 @@ import string
 from datetime import datetime
 from dotenv import load_dotenv
 import aiohttp
+import photo_tools
 from typing import Annotated, Dict, List, Optional, Any
 from pathlib import Path
 from livekit.agents import (
@@ -1089,6 +1090,54 @@ class AssistantFnc(llm.FunctionContext):
             "speech_results": "I couldn't find any details for this research. Would you like me to start a new research task?",
             "chat_results": "I couldn't find any details for this research. Would you like me to start a new research task?"
         }
+
+    @llm.ai_callable()
+    async def generate_image(
+        self,
+        prompt: Annotated[
+            str,
+            llm.TypeInfo(
+                description="Prompt describing the image to generate using Stable Diffusion",
+            ),
+        ],
+    ):
+        """Generate an image from a text prompt using a local Stable Diffusion API."""
+        agent = AgentCallContext.get_current().agent
+        try:
+            await agent.say("Generating the image now.", add_to_chat_ctx=True)
+            path = await photo_tools.generate_image(prompt)
+            return {"image_path": path}
+        except Exception as e:
+            logger.error(f"Image generation failed: {e}")
+            await agent.say("I couldn't create the image.", add_to_chat_ctx=True)
+            return {"error": str(e)}
+
+    @llm.ai_callable()
+    async def edit_image(
+        self,
+        image_path: Annotated[
+            str,
+            llm.TypeInfo(
+                description="Path or URL of the image to edit",
+            ),
+        ],
+        instructions: Annotated[
+            str,
+            llm.TypeInfo(
+                description="Instructions describing how the image should be edited",
+            ),
+        ],
+    ):
+        """Edit an existing image using the local Stable Diffusion API."""
+        agent = AgentCallContext.get_current().agent
+        try:
+            await agent.say("Editing the image now.", add_to_chat_ctx=True)
+            path = await photo_tools.edit_image(image_path, instructions)
+            return {"image_path": path}
+        except Exception as e:
+            logger.error(f"Image editing failed: {e}")
+            await agent.say("I couldn't edit the image.", add_to_chat_ctx=True)
+            return {"error": str(e)}
 
 
 

--- a/photo_tools.py
+++ b/photo_tools.py
@@ -1,0 +1,33 @@
+import os
+import aiohttp
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def _post(url: str, payload: dict) -> dict:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=payload) as resp:
+            if resp.status != 200:
+                text = await resp.text()
+                raise RuntimeError(f"Request failed with status {resp.status}: {text}")
+            return await resp.json()
+
+async def generate_image(prompt: str) -> str:
+    """Generate an image from a text prompt using a local Stable Diffusion API."""
+    url = os.environ.get("IMAGE_GEN_URL", "http://localhost:5004/generate")
+    try:
+        data = await _post(url, {"prompt": prompt})
+        return data.get("url") or data.get("path", "")
+    except Exception as e:
+        logger.error(f"generate_image failed: {e}")
+        raise
+
+async def edit_image(image_path: str, instructions: str) -> str:
+    """Edit an image using a local Stable Diffusion API."""
+    url = os.environ.get("IMAGE_EDIT_URL", "http://localhost:5004/edit")
+    try:
+        data = await _post(url, {"image": image_path, "instructions": instructions})
+        return data.get("url") or data.get("path", "")
+    except Exception as e:
+        logger.error(f"edit_image failed: {e}")
+        raise

--- a/system_prompt.txt
+++ b/system_prompt.txt
@@ -20,6 +20,9 @@ This process takes a few minutes but provides more thorough results than a quick
 You can check the status of ongoing research with check_research_status when the user asks about progress.
 
 
+Image Capabilities:
+You can generate images with generate_image and modify existing images with edit_image using a local Stable Diffusion service.
+
 
 Voice Output Guidelines:
 


### PR DESCRIPTION
## Summary
- add `photo_tools.py` with async functions for image generation and editing via local Stable Diffusion
- expose `generate_image` and `edit_image` in `AssistantFnc`
- mention the new photo capabilities in the system prompt

## Testing
- `python3 -m py_compile dria-agent-deep-research.py photo_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6858a7d56e748330bac4466ae60404fd