### PR TITLE
Add image upload endpoint and edit_image helper

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -30,3 +30,6 @@ SEARCH_API_URL=http://localhost:3100/api/search
 # Search Models (Perplexica)
 SEARCH_CHAT_MODEL= gemma3:latest
 SEARCH_EMBEDDING_MODEL= nomic-embed-text:latest
+# Image Upload
+UPLOAD_DIR=uploads
+UPLOAD_PORT=5001

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ She explains what she's doing and lets you know when research is ready.
 - `system_prompt.txt` – Defines her voice, behavior, and response rules
 - `.env.local` – Place your configs (models, API ports, etc.)
 - `tts.py` – Custom script for TTS
-- `stt.py` – Custom script for STT 
+- `stt.py` – Custom script for STT
+- `image_upload_server.py` – Lightweight FastAPI service for uploading images
 
 ---
 

--- a/dria-agent-deep-research.py
+++ b/dria-agent-deep-research.py
@@ -1090,6 +1090,37 @@ class AssistantFnc(llm.FunctionContext):
             "chat_results": "I couldn't find any details for this research. Would you like me to start a new research task?"
         }
 
+    @llm.ai_callable()
+    async def edit_image(
+        self,
+        image_path: Annotated[
+            str,
+            llm.TypeInfo(
+                description="Path to an uploaded image for editing",
+            ),
+        ],
+        prompt: Annotated[
+            str,
+            llm.TypeInfo(
+                description="Instructions describing the desired edit",
+            ),
+        ],
+    ):
+        """Placeholder for an image editing step.
+
+        Verifies the file exists so the assistant can reference it later.
+        """
+
+        agent = AgentCallContext.get_current().agent
+
+        image_file = Path(image_path)
+        if not image_file.exists():
+            await agent.say("I couldn't find that image file.", add_to_chat_ctx=True)
+            return {"error": "file_not_found"}
+
+        await agent.say("Image received. I'll apply the edit when ready.", add_to_chat_ctx=True)
+        return {"image_path": str(image_file), "prompt": prompt}
+
 
 
 def prewarm(proc: JobProcess):

--- a/image_upload_server.py
+++ b/image_upload_server.py
@@ -1,0 +1,31 @@
+import os
+import uuid
+from pathlib import Path
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+from dotenv import load_dotenv
+
+load_dotenv(dotenv_path=".env.local")
+
+UPLOAD_DIR = Path(os.getenv("UPLOAD_DIR", "uploads"))
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+app = FastAPI()
+
+@app.post("/upload")
+async def upload_image(file: UploadFile = File(...)):
+    ext = Path(file.filename).suffix
+    unique_name = f"{uuid.uuid4().hex}{ext}"
+    destination = UPLOAD_DIR / unique_name
+    with destination.open("wb") as buffer:
+        while True:
+            chunk = await file.read(8192)
+            if not chunk:
+                break
+            buffer.write(chunk)
+    return JSONResponse({"file_path": str(destination)})
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.getenv("UPLOAD_PORT", "5001"))
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- create `image_upload_server.py` with a small FastAPI server for image uploads
- expose `UPLOAD_DIR` and `UPLOAD_PORT` in `.env.local`
- document the new server in README
- add `edit_image` function so the assistant can reference uploaded files

## Testing
- `python -m py_compile dria-agent-deep-research.py image_upload_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6858a7d6a6448330812e98d09dec5486